### PR TITLE
Feature/add projects by solution endpoint

### DIFF
--- a/app/controllers/v1/categories_controller.rb
+++ b/app/controllers/v1/categories_controller.rb
@@ -3,7 +3,7 @@ module V1
   class CategoriesController < ApplicationController
     include ErrorSerializer
 
-    skip_before_action :authenticate, only: [:index, :show]
+    skip_before_action :authenticate, only: [:index, :show, :by_type]
     load_and_authorize_resource class: 'Category'
 
     before_action :set_category, only: [:show, :update, :destroy]

--- a/app/controllers/v1/categories_controller.rb
+++ b/app/controllers/v1/categories_controller.rb
@@ -43,6 +43,20 @@ module V1
       end
     end
 
+    def by_type
+			filters = params[:filters][:type].split(',') rescue ''
+
+			if filters.present?
+				@categories = {
+												data: Category.where(category_type: filters).select(:id, :name, :slug, :description, :category_type, :parent_id).group_by(&:category_type)
+											}
+			else
+				@categories = Category.all
+			end
+
+			render json: @categories
+    end
+
     private
 
       def set_category

--- a/app/controllers/v1/projects_controller.rb
+++ b/app/controllers/v1/projects_controller.rb
@@ -4,7 +4,7 @@ module V1
     include ErrorSerializer
     include ApiUploads
 
-    skip_before_action :authenticate, only: [:index, :show]
+    skip_before_action :authenticate, only: [:index, :show, :by_solution]
     load_and_authorize_resource class: 'Project'
 
     before_action :set_full_project, only: [:show, :show_project_and_bm]
@@ -54,6 +54,11 @@ module V1
       else
         render json: ErrorSerializer.serialize(@project.errors, 422), status: 422
       end
+    end
+
+    def by_solution
+    	@projects = Project.where(category_id: params[:category_id])
+    	render json: @projects, each_serializer: ProjectBySolutionSerializer
     end
 
     private

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -60,6 +60,14 @@ class Category < ApplicationRecord
     end
   end
 
+	def parent_slug
+		self.parent.slug rescue nil
+	end
+
+	def attributes
+		super.merge({'parent_slug' => parent_slug})
+	end
+
   def with_children
     children.includes(children: :parent).distinct
   end

--- a/app/serializers/project_by_solution_serializer.rb
+++ b/app/serializers/project_by_solution_serializer.rb
@@ -1,0 +1,15 @@
+class ProjectBySolutionSerializer < ActiveModel::Serializer
+  attributes :id, :name, :cities, :category
+
+  def cities
+  	object.cities.map { |city| { id: city.id, name: city.name } }
+  end
+
+  def category
+  	{
+  		id: object.category.id,
+  		name: object.category.name,
+  		slug: object.category.slug
+  	}	
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
     get '/categories',                            to: 'categories#index', category_type: 'All'
     get '/categories-tree',                       to: 'categories#index', category_type: 'Tree'
 
+    # Custom endpoints
+    get '/projects-by-solution/:category_id', to: 'projects#by_solution'
+
     # Resources
     resources :users
     resources :cities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
     # Custom endpoints
     get '/projects-by-solution/:category_id', to: 'projects#by_solution'
+    get '/categories_types', to: 'categories#by_type'
 
     # Resources
     resources :users


### PR DESCRIPTION
Since the project is not using jsonapi resources, just created the necessary "filter" routes before actually implementing jsonapi to the project.

Create route to get projects from a specific solution.

Create route to get categories from specific types and return them grouped, couldn't use activemodel serializer for this one because it can't handle group_by collections.