### PR TITLE
Add bme slug filter (include=projects doesn't work)

### DIFF
--- a/app/resources/v1/city_resource.rb
+++ b/app/resources/v1/city_resource.rb
@@ -49,6 +49,10 @@ module V1
       records.joins(projects: :bmes).where('bmes.id = ?', value[0].to_i)
     }
 
+    filter :bme_slug, apply: ->(records, value, _options) {
+      records.joins(projects: :bmes).where('bmes.slug = ?', value[0])
+    }
+
     def custom_links(_)
       { self: nil }
     end


### PR DESCRIPTION
inlude=projects param is not working because of a bug in the jsonapi gem, waiting to check if we'll need to include the projects in this filter.

Edit: not needed